### PR TITLE
Change list table to easily copy/paste payout

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -151,9 +151,7 @@
                   </td>
                   <td>{{ $kill->ship_type }}</td>
                   <td>
-                      <button type="button" class="btn btn-xs btn-link" data-toggle="modal" data-target="#insurances" data-kill-id="{{ $kill->kill_id }}">
-                          {{ number_format($kill->cost, 2) }} ISK
-                      </button>
+                          {{ number_format($kill->cost, 2) }}
                   </td>
                   <td id="id-arch-{{ $kill->kill_id }}">
                   @if ($kill->approved === 0)


### PR DESCRIPTION
User feedback indicated that it was way more important to be able to quickly copy/paste from this table instead of viewing insurance information, which may already be used in the calculation.